### PR TITLE
refactor: pending transaction polling on contract calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,12 +176,15 @@ forge bind  --select "(?:^|\W)PayoutFactory|PaymentSplitter(?:$|\W)" --crate-nam
 ## Cli
 
 To use the bindings as scripts to deploy and interact with contracts first create a `./secrets/secret` file within `./cli` containing your mnemonic string (not this should only be used for testing purposes !).
-Then:
+
 ```bash
 cd ./cli
-cargo run --bin saturn-contracts deploy -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1
+cargo run --bin saturn-contracts deploy -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1 --retries=10
 
 ```
+
+> **Note:** The `--retries` parameter sets a number of times to poll a pending transaction before considering it as having failed. Because of the differences in block times between Filecoin / Hyperspace and Ethereum, `ethers-rs` can sometimes timeout prematurely _before_ a transaction has truly failed or succeeded (`ethers-rs` has been built with Ethereum in mind). `--retries` has a default value of 10, which empirically we have found to result in successful transactions.
+
 To deploy a new `PaymentSplitter` from a deployed `PayoutFactory` contract:
 - Set an env var called `FACTORY_ADDRESS` with the address of the deployed `PayoutFactory`.
 - Generate a csv file with the headers `payee,shares` and fill out the rows with pairs of addresses and shares.
@@ -189,5 +192,6 @@ To deploy a new `PaymentSplitter` from a deployed `PayoutFactory` contract:
 Run:
 ```bash
 cd ./cli
-cargo run --bin saturn-contracts new-payout  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -P ./secrets/payouts.csv
+cargo run --bin saturn-contracts new-payout  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -P ./secrets/payouts.csv --retries=10
 ```
+

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -378,10 +378,10 @@ dependencies = [
  "contract-bindings",
  "csv",
  "ethers",
- "eyre",
  "log",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 [dependencies]
 contract-bindings = { path= "./bindings" }
 clap = { version = "4.0.32", features = ["derive"] }
+thiserror = "1.0.38"
 ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, rev = 'ee5e3e52', features = ["abigen"]  }
 tokio = { version = "1.17.0", features = ["macros"] }
-eyre = "0.6.6"
 serde_json = "1.0.91"
 serde = "1.0.152"
 log = { version = "0.4.17" }

--- a/cli/src/bin/saturn-contracts.rs
+++ b/cli/src/bin/saturn-contracts.rs
@@ -1,15 +1,17 @@
 use cli::commands::Cli;
 use cli::utils::banner;
-use eyre::Result;
-use log::error;
+use log::{error, info};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     colog::init();
     banner();
 
     match Cli::create() {
-        Ok(cli) => cli.run().await,
+        Ok(cli) => match cli.run().await {
+            Ok(_) => info!("success"),
+            Err(e) => error!("{}", e),
+        },
         Err(e) => error!("{}", e),
     }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -57,8 +57,8 @@ impl Cli {
                     "Estimated deployment gas cost {:#?}",
                     client.estimate_gas(&tx, None).await.unwrap()
                 );
-                let deploy_result = contract.call().await.unwrap();
-                debug!("deploy result: {:#?}", deploy_result)
+                let deploy_transaction = contract.send().await.unwrap();
+                debug!("Deploy Receipt: {:#?}", deploy_transaction)
             }
             Commands::NewPayout {
                 secret,

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -57,8 +57,8 @@ impl Cli {
                     "Estimated deployment gas cost {:#?}",
                     client.estimate_gas(&tx, None).await.unwrap()
                 );
-                let deploy_transaction = contract.send().await.unwrap();
-                debug!("Deploy Receipt: {:#?}", deploy_transaction)
+                let deploy_result = contract.call().await.unwrap();
+                debug!("deploy result: {:#?}", deploy_result)
             }
             Commands::NewPayout {
                 secret,

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use ::ethers::contract::Contract;
 use ethers::abi::AbiEncode;
 use ethers::core::k256::{ecdsa::SigningKey, elliptic_curve::sec1::ToEncodedPoint, PublicKey};
@@ -11,11 +10,10 @@ use ethers::{
     providers::{Http, Provider},
     signers::Wallet,
 };
-use eyre::Result;
+use log::{debug, info};
 use serde_json::ser;
 use std::fs;
-use log::{debug, info};
-
+use std::sync::Arc;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 
@@ -73,7 +71,7 @@ pub fn addr(mnemonic: &str) -> Result<H160, Bytes> {
 fn get_signing_wallet(private_key: U256, chain_id: u64) -> Wallet<SigningKey> {
     let private_key = parse_private_key(private_key).unwrap();
     let wallet: Wallet<ethers::core::k256::ecdsa::SigningKey> = private_key.into();
-    
+
     wallet.with_chain_id(chain_id)
 }
 
@@ -90,7 +88,7 @@ pub async fn get_signing_provider(
     let signing_wallet = get_signing_wallet(private_key, chain_id.as_u64());
 
     let provider = Arc::new(provider);
-    
+
     SignerMiddleware::new(provider, signing_wallet)
 }
 
@@ -118,4 +116,3 @@ pub fn banner() {
         )
     );
 }
-


### PR DESCRIPTION
Currently the cli creates a new `PendingTransaction` after a call is initiated. We should (in theory) poll this to completion to get a guarantee of a successful call. 

This PR: 
- [x] polls pendingtransactions for a receipt
- [x] additionally creates consistent error handling and logging