### PR TITLE
feat: claim cmd for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To use the bindings as scripts to deploy and interact with contracts first creat
 
 ```bash
 cd ./cli
-cargo run --bin saturn-contracts deploy -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1 --retries=10
+cargo run --bin saturn-contracts -- -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1 --retries=10 deploy 
 
 ```
 
@@ -192,11 +192,11 @@ To deploy a new `PaymentSplitter` from a deployed `PayoutFactory` contract:
 Run:
 ```bash
 cd ./cli
-cargo run --bin saturn-contracts new-payout  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -P ./secrets/payouts.csv --retries=10
+cargo run --bin saturn-contracts -- -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1 --retries=10 new-payout -F $FACTORY_ADDRESS -P ./secrets/payouts.csv 
 ```
 
 You can then claim funds for a specific payee using the cli: 
 ```bash
 cd ./cli
-cargo run --bin saturn-contracts claim  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -A $CLAIM_ADDRESS --retries=10
+cargo run --bin saturn-contracts -- -S secrets/.secret -U https://api.hyperspace.node.glif.io/rpc/v1 --retries=10 claim -F $FACTORY_ADDRESS -A $CLAIM_ADDRESS 
 ```

--- a/README.md
+++ b/README.md
@@ -195,3 +195,8 @@ cd ./cli
 cargo run --bin saturn-contracts new-payout  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -P ./secrets/payouts.csv --retries=10
 ```
 
+You can then claim funds for a specific payee using the cli: 
+```bash
+cd ./cli
+cargo run --bin saturn-contracts claim  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -A $CLAIM_ADDRESS --retries=10
+```

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -143,16 +143,16 @@ impl Cli {
 
                 let factory = PayoutFactory::new(addr, client.clone().into());
                 let claim_addr = Address::from_str(addr_to_claim.as_str())?;
-                let mut payout_tx = factory.release_all(claim_addr);
+                let mut claim_tx = factory.release_all(claim_addr);
                 let gas = client.provider().get_gas_price().await?;
                 info!("gas price: {:#?}", gas);
 
                 let gas_estimate =
-                    client.estimate_gas(&payout_tx.tx, None).await? * GAS_LIMIT_MULTIPLIER / 100;
-                payout_tx.tx.set_gas_price(gas);
-                payout_tx.tx.set_gas(gas_estimate);
+                    client.estimate_gas(&claim_tx.tx, None).await? * GAS_LIMIT_MULTIPLIER / 100;
+                claim_tx.tx.set_gas_price(gas);
+                claim_tx.tx.set_gas(gas_estimate);
 
-                let pending_tx = payout_tx.send().await?;
+                let pending_tx = claim_tx.send().await?;
                 let hash = pending_tx.tx_hash();
                 info!("using {} retries", retries);
                 let receipt = pending_tx.retries(*retries).await?;

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,28 +1,16 @@
-use crate::utils::{addr, get_signing_provider};
+use crate::utils::{get_signing_provider, send_tx, set_tx_gas, CLIError};
 use clap::{Parser, Subcommand};
 use contract_bindings::payout_factory::PayoutFactory;
 use ethers::abi::Address;
 use ethers::prelude::Middleware;
-use ethers::types::{H256, U256};
-use log::{debug, error, info};
+use ethers::types::U256;
+use log::info;
 use serde::{Deserialize, Serialize};
 use std::fs::read_to_string;
 use std::path::PathBuf;
 use std::str::FromStr;
-use thiserror::Error;
 
-const GAS_LIMIT_MULTIPLIER: i32 = 130;
 const ATTO_FIL: u128 = 10_u128.pow(18);
-
-#[derive(Error, Debug)]
-pub enum CLIError {
-    #[error(
-        "did not receive receipt, but check a hyperspace explorer to check if tx was successful (hash: ${0})"
-    )]
-    NoReceipt(H256),
-    #[error("contract failed to deploy")]
-    ContractNotDeployed,
-}
 
 #[allow(missing_docs)]
 #[derive(Parser, Debug, Clone, Deserialize, Serialize)]
@@ -31,6 +19,15 @@ pub struct Cli {
     #[command(subcommand)]
     #[allow(missing_docs)]
     pub command: Commands,
+    /// Path to the wallet mnemonic
+    #[arg(short = 'S', long)]
+    secret: PathBuf,
+    /// RPC Url
+    #[arg(short = 'U', long)]
+    rpc_url: String,
+    // Num of retries when attempting to make a transaction.
+    #[arg(long, default_value = "10")]
+    retries: usize,
 }
 
 #[derive(Deserialize, Debug)]
@@ -45,60 +42,42 @@ impl Cli {
     }
 
     pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mnemonic = read_to_string(self.secret.clone())?;
+        let client = get_signing_provider(&mnemonic, &self.rpc_url).await;
+
+        let gas_price = client.provider().get_gas_price().await?;
+
+        info!("current gas price: {:#?}", gas_price);
+
+        info!("using {} retries", self.retries);
+
         match &self.command {
-            Commands::Deploy {
-                secret,
-                rpc_url,
-                retries,
-            } => {
-                let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, rpc_url).await;
-                let addr: Address = addr(&mnemonic).unwrap();
-                let mut contract = PayoutFactory::deploy(client.clone().into(), addr)?;
-
-                let gas = client.provider().get_gas_price().await?;
-                info!("gas price {:#?}: ", gas);
-
+            Commands::Deploy {} => {
+                let mut contract = PayoutFactory::deploy(client.clone().into(), client.address())?;
                 let tx = contract.deployer.tx.clone();
-                let gas_estimate =
-                    client.estimate_gas(&tx, None).await? * GAS_LIMIT_MULTIPLIER / 100;
-                contract.deployer.tx.set_gas(gas_estimate);
-                contract.deployer.tx.set_gas_price(gas);
-
-                debug!("{:#?}", tx);
-                info!(
-                    "estimated deployment gas cost {:#?}",
-                    client.estimate_gas(&tx, None).await?
+                set_tx_gas(
+                    &mut contract.deployer.tx,
+                    client.estimate_gas(&tx, None).await?,
+                    gas_price,
                 );
 
-                let deployer = contract.deployer;
-                let pending_tx = client.send_transaction(deployer.tx, None).await?;
+                info!(
+                    "estimated deployment gas cost: {:#?}",
+                    contract.deployer.tx.gas().unwrap()
+                );
 
-                let hash = pending_tx.tx_hash();
-                info!("using {} retries", retries);
-                let receipt = pending_tx.retries(*retries).await?;
-                if receipt.is_some() {
-                    let receipt = receipt.unwrap();
-                    debug!("call receipt: {:#?}", receipt);
-                    let address = receipt
-                        .contract_address
-                        .ok_or(CLIError::ContractNotDeployed)?;
-                    info!("contract address: {:#?}", address);
-                } else {
-                    return Err(Box::new(CLIError::NoReceipt(hash)));
-                }
+                let receipt = send_tx(&contract.deployer.tx, client, self.retries).await?;
+
+                let address = receipt
+                    .contract_address
+                    .ok_or(CLIError::ContractNotDeployed)?;
+                info!("contract address: {:#?}", address);
             }
             Commands::NewPayout {
-                secret,
-                rpc_url,
                 factory_addr,
                 payout_csv,
-                retries,
             } => {
-                let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, rpc_url).await;
-                let addr = Address::from_str(factory_addr.as_str())?;
-
+                let addr = Address::from_str(factory_addr)?;
                 let mut reader = csv::Reader::from_path(payout_csv)?;
                 let mut shares: Vec<U256> = Vec::new();
                 let mut payees: Vec<Address> = Vec::new();
@@ -112,55 +91,38 @@ impl Cli {
 
                 let factory = PayoutFactory::new(addr, client.clone().into());
                 let mut payout_tx = factory.payout(payees, shares);
-                let gas = client.provider().get_gas_price().await?;
-                info!("gas price: {:#?}", gas);
+                let tx = payout_tx.tx.clone();
+                set_tx_gas(
+                    &mut payout_tx.tx,
+                    client.estimate_gas(&tx, None).await?,
+                    gas_price,
+                );
 
-                let gas_estimate =
-                    client.estimate_gas(&payout_tx.tx, None).await? * GAS_LIMIT_MULTIPLIER / 100;
-                payout_tx.tx.set_gas_price(gas);
-                payout_tx.tx.set_gas(gas_estimate);
+                info!(
+                    "estimated payout gas cost {:#?}",
+                    payout_tx.tx.gas().unwrap()
+                );
 
-                let pending_tx = payout_tx.send().await?;
-                let hash = pending_tx.tx_hash();
-                info!("using {} retries", retries);
-                let receipt = pending_tx.retries(*retries).await?;
-                if receipt.is_some() {
-                    debug!("call receipt: {:#?}", receipt.unwrap());
-                } else {
-                    return Err(Box::new(CLIError::NoReceipt(hash)));
-                }
+                send_tx(&payout_tx.tx, client, self.retries).await?;
             }
             Commands::Claim {
-                secret,
-                rpc_url,
                 factory_addr,
                 addr_to_claim,
-                retries,
             } => {
-                let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, rpc_url).await;
-                let addr = Address::from_str(factory_addr.as_str())?;
-
+                let addr = Address::from_str(factory_addr)?;
                 let factory = PayoutFactory::new(addr, client.clone().into());
                 let claim_addr = Address::from_str(addr_to_claim.as_str())?;
                 let mut claim_tx = factory.release_all(claim_addr);
-                let gas = client.provider().get_gas_price().await?;
-                info!("gas price: {:#?}", gas);
+                let tx = claim_tx.tx.clone();
+                set_tx_gas(
+                    &mut claim_tx.tx,
+                    client.estimate_gas(&tx, None).await?,
+                    gas_price,
+                );
 
-                let gas_estimate =
-                    client.estimate_gas(&claim_tx.tx, None).await? * GAS_LIMIT_MULTIPLIER / 100;
-                claim_tx.tx.set_gas_price(gas);
-                claim_tx.tx.set_gas(gas_estimate);
+                info!("estimated claim gas cost {:#?}", claim_tx.tx.gas().unwrap());
 
-                let pending_tx = claim_tx.send().await?;
-                let hash = pending_tx.tx_hash();
-                info!("using {} retries", retries);
-                let receipt = pending_tx.retries(*retries).await?;
-                if receipt.is_some() {
-                    debug!("call receipt: {:#?}", receipt.unwrap());
-                } else {
-                    return Err(Box::new(CLIError::NoReceipt(hash)));
-                }
+                send_tx(&claim_tx.tx, client, self.retries).await?;
             }
         }
         Ok(())
@@ -171,54 +133,25 @@ impl Cli {
 #[derive(Debug, Subcommand, Clone, Deserialize, Serialize)]
 pub enum Commands {
     /// Deploys a new payout factory contract
-    #[command(arg_required_else_help = true)]
-    Deploy {
-        /// The path to the wallet mnemonic
-        #[arg(short = 'S', long)]
-        secret: PathBuf,
-        /// RPC Url
-        #[arg(short = 'U', long)]
-        rpc_url: String,
-        // Num of retries when attempting to make a transaction.
-        #[arg(long, default_value = "10")]
-        retries: usize,
-    },
+    Deploy,
     /// Creates a new paymentsplitter based payout
     #[command(arg_required_else_help = true)]
     NewPayout {
-        /// Path to the wallet mnemonic
-        #[arg(short = 'S', long)]
-        secret: PathBuf,
-        /// RPC Url
-        #[arg(short = 'U', long)]
-        rpc_url: String,
         /// Path to the wallet mnemonic
         #[arg(short = 'F', long)]
         factory_addr: String,
         // Path to csv payout file.
         #[arg(short = 'P', long)]
         payout_csv: PathBuf,
-        // Num of retries when attempting to make a transaction.
-        #[arg(long, default_value = "10")]
-        retries: usize,
     },
     /// Claims all available funds for a given address
     #[command(arg_required_else_help = true)]
     Claim {
-        /// Path to the wallet mnemonic
-        #[arg(short = 'S', long)]
-        secret: PathBuf,
-        /// RPC Url
-        #[arg(short = 'U', long)]
-        rpc_url: String,
         /// Path to the wallet mnemonic
         #[arg(short = 'F', long)]
         factory_addr: String,
         // Address to claim for
         #[arg(short = 'A', long)]
         addr_to_claim: String,
-        // Num of retries when attempting to make a transaction.
-        #[arg(long, default_value = "10")]
-        retries: usize,
     },
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -52,7 +52,7 @@ impl Cli {
                 retries,
             } => {
                 let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, &rpc_url).await;
+                let client = get_signing_provider(&mnemonic, rpc_url).await;
                 let addr: Address = addr(&mnemonic).unwrap();
                 let mut contract = PayoutFactory::deploy(client.clone().into(), addr)?;
 
@@ -96,7 +96,7 @@ impl Cli {
                 retries,
             } => {
                 let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, &rpc_url).await;
+                let client = get_signing_provider(&mnemonic, rpc_url).await;
                 let addr = Address::from_str(factory_addr.as_str())?;
 
                 let mut reader = csv::Reader::from_path(payout_csv)?;
@@ -138,7 +138,7 @@ impl Cli {
                 retries,
             } => {
                 let mnemonic = read_to_string(secret)?;
-                let client = get_signing_provider(&mnemonic, &rpc_url).await;
+                let client = get_signing_provider(&mnemonic, rpc_url).await;
                 let addr = Address::from_str(factory_addr.as_str())?;
 
                 let factory = PayoutFactory::new(addr, client.clone().into());

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -170,7 +170,7 @@ impl Cli {
 #[allow(missing_docs)]
 #[derive(Debug, Subcommand, Clone, Deserialize, Serialize)]
 pub enum Commands {
-    /// Loads model and prints model table
+    /// Deploys a new payout factory contract
     #[command(arg_required_else_help = true)]
     Deploy {
         /// The path to the wallet mnemonic
@@ -183,6 +183,7 @@ pub enum Commands {
         #[arg(long, default_value = "10")]
         retries: usize,
     },
+    /// Creates a new paymentsplitter based payout
     #[command(arg_required_else_help = true)]
     NewPayout {
         /// Path to the wallet mnemonic
@@ -201,6 +202,7 @@ pub enum Commands {
         #[arg(long, default_value = "10")]
         retries: usize,
     },
+    /// Claims all available finds for a given address
     #[command(arg_required_else_help = true)]
     Claim {
         /// Path to the wallet mnemonic

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -202,7 +202,7 @@ pub enum Commands {
         #[arg(long, default_value = "10")]
         retries: usize,
     },
-    /// Claims all available finds for a given address
+    /// Claims all available funds for a given address
     #[command(arg_required_else_help = true)]
     Claim {
         /// Path to the wallet mnemonic

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -31,11 +31,9 @@ fn derive_key(mnemonic: &str, path: &str, index: u32) -> Result<U256, Bytes> {
         .build()
         .map_err(|err| err.to_string().encode())?;
 
-    info!("Wallet key we use: {:#?}", wallet);
+    info!("wallet address: {:#?}", wallet.address());
 
     let private_key = U256::from_big_endian(wallet.signer().to_bytes().as_slice());
-
-    info!("Private key we use: {:#?}", private_key);
 
     Ok(private_key)
 }


### PR DESCRIPTION
Some more sophisticated users may want access to simple tools for programmatic claiming of funds (eg. if have multiple wallets or want to `cron` it). 

This PR introduces a claim command on the cli. 

```rust
/// Claims all available funds for a given address
    #[command(arg_required_else_help = true)]
    Claim {
        /// Path to the wallet mnemonic
        #[arg(short = 'S', long)]
        secret: PathBuf,
        /// RPC Url
        #[arg(short = 'U', long)]
        rpc_url: String,
        /// Path to the wallet mnemonic
        #[arg(short = 'F', long)]
        factory_addr: String,
        // Address to claim for
        #[arg(short = 'A', long)]
        addr_to_claim: String,
        // Num of retries when attempting to make a transaction.
        #[arg(long, default_value = "10")]
        retries: usize,
    },


```

It is used as such: 

```bash
saturn-contracts claim  -S ./secrets/.secret -U $RPC_URL -F $FACTORY_ADDRESS -A $CLAIM_ADDRESS --retries=10
```

- [x] `claim` command for cli 
- [x] update readme 

