### PR TITLE
feat: filecoin to eth address conversion

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -108,6 +108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base32"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
+
+[[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,11 +379,14 @@ dependencies = [
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "base32",
+ "blake2",
  "clap",
  "colog",
  "contract-bindings",
  "csv",
  "ethers",
+ "leb128",
  "log",
  "serde",
  "serde_json",
@@ -1514,6 +1523,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,3 +14,6 @@ serde = "1.0.152"
 log = { version = "0.4.17" }
 colog = { version = "1.1.0" }
 csv = "1.2.0"
+base32 = "0.4.0"
+leb128 = "0.2.5"
+blake2 = "0.10.6"

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -354,7 +354,7 @@ fn check_address_string(address: &str) -> Result<AddressData, AddressError> {
 /// let addr = "t05088";
 /// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff000000000000000000000000000000000013e0");
 ///
-/// /// /// test delegated addresses
+/// // test delegated addresses
 /// let addr = "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa";  
 /// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0x52963ef50e27e06d72d59fcb4f3c2a687be3cfef");
 ///

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,4 +1,6 @@
 use ::ethers::contract::Contract;
+use blake2::digest::{Update, VariableOutput};
+use blake2::Blake2bVar;
 use ethers::abi::AbiEncode;
 use ethers::core::k256::{ecdsa::SigningKey, elliptic_curve::sec1::ToEncodedPoint, PublicKey};
 use ethers::core::{types::Address, utils::keccak256};
@@ -11,13 +13,103 @@ use ethers::{
     providers::{Http, Provider},
     signers::Wallet,
 };
+use leb128 as leb;
 use log::{debug, info};
 use serde_json::ser;
+use std::fmt::Write;
 use std::fs;
 use std::sync::Arc;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
 const GAS_LIMIT_MULTIPLIER: i32 = 130;
+// The hash length used for calculating address checksums.
+const CHECKSUM_HASH_LENGTH: usize = 4;
+
+// The maximum length of `int64` as a string.
+const MAX_INT64_STRING_LENGTH: usize = 19;
+
+// The maximum length of a delegated address's sub-address.
+const MAX_SUBADDRESS_LEN: usize = 54;
+
+const ETH_ADDRESS_LENGTH: usize = 20;
+
+enum CoinType {
+    MAIN,
+    TEST,
+}
+
+impl CoinType {
+    fn possible_values() -> [char; 2] {
+        ['f', 't']
+    }
+}
+
+impl From<char> for CoinType {
+    fn from(a: char) -> Self {
+        match a {
+            'f' => CoinType::MAIN,
+            't' => CoinType::TEST,
+            _ => panic!(),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone)]
+enum Protocol {
+    ID = 0,
+    SECP256K1 = 1,
+    ACTOR = 2,
+    BLS = 3,
+    DELEGATED = 4,
+}
+
+impl Protocol {
+    fn possible_values() -> [u64; 5] {
+        [0, 1, 2, 3, 4]
+    }
+}
+
+impl From<u64> for Protocol {
+    fn from(a: u64) -> Self {
+        match a {
+            0 => Protocol::ID,
+            1 => Protocol::SECP256K1,
+            2 => Protocol::ACTOR,
+            3 => Protocol::BLS,
+            4 => Protocol::DELEGATED,
+            _ => panic!(),
+        }
+    }
+}
+
+pub struct AddressData {
+    protocol: Protocol,
+    payload: Vec<u8>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum AddressError {
+    #[error(
+        "Address cointype should be one of: {:#?}",
+        CoinType::possible_values()
+    )]
+    InvalidCointype,
+    #[error(
+        "Address protocol should be one of: {:#?}",
+        Protocol::possible_values()
+    )]
+    InvalidProtocol,
+    #[error("invalid address")]
+    InvalidAddress,
+    #[error("invalid base32")]
+    InvalidBase32,
+    #[error("invalid leb128")]
+    InvalidLeb128,
+    #[error("invalid checksum")]
+    InvalidChecksum,
+    #[error("can only convert delegated addresses to ETH")]
+    OnlyConvertDelegated,
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum CLIError {
@@ -132,6 +224,170 @@ pub fn write_abi(contract: Contract<SignerMiddleware<Arc<Provider<Http>>, Wallet
     let abi = contract.abi();
     let string_abi = ser::to_string(abi).unwrap();
     fs::write("./factoryAbi.json", string_abi).expect("Unable to write file");
+}
+
+fn validate_checksum(bytes: &[u8], checksum_bytes: &[u8]) -> bool {
+    let mut hasher = Blake2bVar::new(CHECKSUM_HASH_LENGTH).unwrap();
+    hasher.update(bytes);
+    let mut buf = [0u8; CHECKSUM_HASH_LENGTH];
+    hasher.finalize_variable(&mut buf).unwrap();
+    buf == checksum_bytes
+}
+
+fn check_address_string(address: &str) -> Result<AddressData, AddressError> {
+    info!("converting {} to ETH equivalent", address);
+    let base32_alphabet = base32::Alphabet::RFC4648 { padding: false };
+    if address.len() < 3 {
+        return Err(AddressError::InvalidAddress);
+    }
+
+    let coin_type = address.chars().nth(0).unwrap();
+    if !CoinType::possible_values().contains(&coin_type) {
+        return Err(AddressError::InvalidCointype);
+    }
+
+    let protocol = address.chars().nth(1).unwrap();
+    // It works because the ASCII (and thus UTF-8) encodings have the Arabic numerals 0-9 ordered in ascending order.
+    // You can get the scalar values and subtract them.
+    let protocol = protocol as u64 - '0' as u64;
+    if !Protocol::possible_values().contains(&protocol) {
+        return Err(AddressError::InvalidProtocol);
+    }
+    let protocol = (protocol as u64).into();
+
+    let raw = &address[2..];
+
+    let addr = match protocol {
+        Protocol::ID => {
+            if raw.len() > MAX_INT64_STRING_LENGTH {
+                return Err(AddressError::InvalidAddress);
+            }
+            if raw.parse::<u64>().is_err() {
+                return Err(AddressError::InvalidAddress);
+            }
+            let mut buf: [u8; 6] = [0; 6];
+            let payload_num_bytes = {
+                let mut writable = &mut buf[..];
+                println!("raw parsed {}", raw.parse::<u64>().unwrap());
+                leb::write::unsigned(&mut writable, raw.parse::<u64>().unwrap())
+                    .map_err(|_| AddressError::InvalidLeb128)?
+            };
+            AddressData {
+                protocol,
+                payload: buf[..payload_num_bytes].to_vec(),
+            }
+        }
+        Protocol::DELEGATED => {
+            let split_index = raw.find('f').unwrap();
+            let namespace_str = &raw[..split_index];
+            if namespace_str.len() > MAX_INT64_STRING_LENGTH {
+                return Err(AddressError::InvalidAddress);
+            }
+            let sub_addr_cksm_str = &raw[split_index + 1..];
+            let sub_addr_cksm_bytes = base32::decode(base32_alphabet, sub_addr_cksm_str)
+                .ok_or(AddressError::InvalidBase32)?;
+            if sub_addr_cksm_bytes.len() < CHECKSUM_HASH_LENGTH {
+                return Err(AddressError::InvalidAddress);
+            }
+            let sub_addr_bytes =
+                &sub_addr_cksm_bytes[..sub_addr_cksm_bytes.len() - CHECKSUM_HASH_LENGTH];
+            let checksum_bytes = &sub_addr_cksm_bytes[sub_addr_bytes.len()..];
+            if sub_addr_bytes.len() > MAX_SUBADDRESS_LEN {
+                return Err(AddressError::InvalidAddress);
+            }
+            let mut protocol_buf: [u8; 1024] = [0; 1024];
+            let protocol_byte_num = {
+                let mut writable = &mut protocol_buf[..];
+                leb::write::unsigned(&mut writable, protocol.clone() as u64)
+                    .map_err(|_| AddressError::InvalidLeb128)?
+            };
+            if protocol_byte_num != 1 {
+                return Err(AddressError::InvalidLeb128);
+            }
+            let protocol_byte = protocol_buf[0..protocol_byte_num].to_vec();
+
+            let mut namespace_buf: [u8; 1024] = [0; 1024];
+            let namespace_number = namespace_str.parse::<u64>().unwrap();
+            let namespace_byte_num = {
+                let mut writable = &mut namespace_buf[..];
+                leb::write::unsigned(&mut writable, namespace_number)
+                    .map_err(|_| AddressError::InvalidLeb128)?
+            };
+            if namespace_byte_num != 1 {
+                return Err(AddressError::InvalidLeb128);
+            }
+            let namespace_byte = namespace_buf[0..namespace_byte_num].to_vec();
+
+            let bytes = [
+                protocol_byte.as_slice(),
+                namespace_byte.as_slice(),
+                sub_addr_bytes,
+            ]
+            .concat();
+
+            if !validate_checksum(&bytes, checksum_bytes) {
+                return Err(AddressError::InvalidChecksum);
+            }
+            let namespace_buf = namespace_number.to_be_bytes();
+            let payload = [&namespace_buf, sub_addr_bytes].concat();
+
+            AddressData { protocol, payload }
+        }
+        _ => {
+            unimplemented!()
+        }
+    };
+    Ok(addr)
+}
+
+/// Converts a filecoin address to a corresponding ETH address
+///
+///```
+/// use cli::utils::filecoin_to_eth_address;
+///
+
+/// // test ID type addresses
+/// let addr = "t01";
+/// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff00000000000000000000000000000000000001");
+/// let addr = "t0100";
+/// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff00000000000000000000000000000000000064");
+/// let addr = "t05088";
+/// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff000000000000000000000000000000000013e0");
+///
+/// /// /// test delegated addresses
+/// let addr = "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa";  
+/// assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0x52963ef50e27e06d72d59fcb4f3c2a687be3cfef");
+///
+
+/// ```
+///
+pub fn filecoin_to_eth_address(address: &str) -> Result<String, AddressError> {
+    let address_data = check_address_string(address)?;
+    let addr_buffer = if matches!(address_data.protocol, Protocol::DELEGATED) {
+        let sub_addr = &address_data.payload[8..];
+        sub_addr.to_vec()
+    } else if matches!(address_data.protocol, Protocol::ID) {
+        let id = leb::read::unsigned(&mut &address_data.payload[..])
+            .map_err(|_| AddressError::InvalidLeb128)?;
+        let mut addr_buffer: Vec<u8> = vec![0; ETH_ADDRESS_LENGTH];
+        addr_buffer[0] = 255_u8.to_be_bytes()[0];
+        let id_bytes = &id.to_be_bytes()[0..8];
+        for i in 12..20 {
+            addr_buffer[i] = id_bytes[i - 12];
+        }
+        addr_buffer
+    } else {
+        unimplemented!()
+    };
+    let mut s = String::with_capacity(ETH_ADDRESS_LENGTH * 2);
+    write!(&mut s, "0x").unwrap();
+    for b in addr_buffer {
+        write!(&mut s, "{:02x}", b).unwrap();
+    }
+
+    info!("ETH equivalent is {}", s);
+
+    Ok(s)
 }
 
 pub fn banner() {


### PR DESCRIPTION
There are currently no (that we know of) implementations of filecoin address to eth equivalent converters. To aid in the deployment of payouts from Filecoin addresses this PR: 

- Implements: 
```rust 
filecoin_to_eth_address(address: &str) -> Result<String, AddressError>
```
- Adds corresponding doc string tests that can be run with `cargo test --doc`

Example usage: 

```rust
use cli::utils::filecoin_to_eth_address;


// test ID type addresses
let addr = "t01";
assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff00000000000000000000000000000000000001");
let addr = "t0100";
assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff00000000000000000000000000000000000064");
let addr = "t05088";
assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0xff000000000000000000000000000000000013e0");

// test delegated addresses
let addr = "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa";  
assert_eq!(filecoin_to_eth_address(addr).unwrap(), "0x52963ef50e27e06d72d59fcb4f3c2a687be3cfef");
```