### PR TITLE
fix: uncomment payout send tx

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -103,7 +103,7 @@ impl Cli {
                     payout_tx.tx.gas().unwrap()
                 );
 
-                // send_tx(&payout_tx.tx, client, self.retries).await?;
+                send_tx(&payout_tx.tx, client, self.retries).await?;
             }
             Commands::Claim {
                 factory_addr,


### PR DESCRIPTION
## Changes:
- uncommenting the line to send the transaction for new payouts. 