### PR TITLE
feat: lotus lite node boot script

### DIFF
--- a/cli/lotus_lite_init.sh
+++ b/cli/lotus_lite_init.sh
@@ -1,0 +1,44 @@
+REQUIRED_PKG="lotus"
+
+
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    echo "[$(date)] -- Detected Linux"
+        # ...
+    REQUIRED_PKG="some-package"
+    PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $REQUIRED_PKG|grep "install ok installed")
+    echo "[$(date)] -- Checking for $REQUIRED_PKG"
+    if [ "" = "$PKG_OK" ]; then
+        echo "No $REQUIRED_PKG. Setting up $REQUIRED_PKG."
+        sudo apt-get --yes install hwloc
+        wget https://github.com/filecoin-project/lotus/releases/download/v1.19.0/lotus_1.19.0_linux_amd64.tar.gz
+        tar -xvf lotus_1.19.0_linux_amd64.tar.gz
+        sudo mv lotus_1.19.0_linux_amd64/lotus /usr/local/bin/lotus
+    fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "[$(date)] -- Detected Mac OSX"
+        # Mac OSX
+    PKG_OK=$(brew list lotus)
+    echo "[$(date)] -- Checking for $REQUIRED_PKG"
+    if [ "" = "$PKG_OK" ]; then
+        echo "[$(date)] -- No $REQUIRED_PKG. Setting up $REQUIRED_PKG."
+        brew tap filecoin-project/lotus
+        brew install lotus
+    fi
+else 
+    echo "Unsupported OS"
+    exit 1
+fi
+
+echo "[$(date)] -- Starting lotus lite daemon."
+FULLNODE_API_INFO="wss://wss.node.glif.io/apigw/lotus" nohup lotus daemon --lite > node.log 2>&1 &
+echo "[$(date)] -- Node pid: $!. Check node.log for logs if an issue arises."   
+echo "[$(date)] -- Started daemon. Waiting 5 seconds for it to finish setting up."
+sleep 5
+
+read -p "[$(date)] -- Do you wish to import a private key? [y/n] " yn
+case $yn in
+    [Yy]* ) lotus wallet import; break;;
+    [Nn]* ) exit;;
+    * ) echo "Please answer yes or no.";;
+esac


### PR DESCRIPTION
Unfortunately glif nodes require a lotus-lite node to interact with some of the multisig capabilities. Here we add a script which makes booting such a node as easy as possible on both linux and macos. 

The script: 

1. Checks if lotus is installed 
2. If not then it downloads and installs as required (depending on platform) 
3. It boots the node, pulling in the `FULLNODE_API_INFO` 
4. Prints the node's PID (can grab this later to kill the process)
5. Asks the user if they want to import a private key -- and reads it in if yes (secretly) 


Example usage: 

```bash 
FULLNODE_API_INFO=wss://wss.node.glif.io/apigw/lotus sh lotus_lite_init.sh
```

Building on this we should: 
- run the script automatically from the rust cli and 
    - inject the `FULLNODE_API_INFO` env var from the cli command
    - inject the user's private key straight into the private key query when asked 
    - destroy the process once the command is executed