### PR TITLE
Fix warnings

### DIFF
--- a/cli/extras/src/json.rs
+++ b/cli/extras/src/json.rs
@@ -1,7 +1,6 @@
 pub mod address {
     use fvm_shared::address::{Address, Network};
     use serde::{de, Deserialize, Deserializer, Serializer};
-    use std::str::FromStr;
 
     pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -78,7 +77,6 @@ pub mod rawbytes {
 pub mod vec_address {
     use fvm_shared::address::{Address, Network};
     use serde::{de, Deserialize, Deserializer, Serializer};
-    use std::str::FromStr;
 
     pub fn serialize<S>(addresses: &Vec<Address>, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/cli/signer/src/api.rs
+++ b/cli/signer/src/api.rs
@@ -234,9 +234,9 @@ impl TryFrom<MessageTxNetwork> for MessageTxAPI {
     fn try_from(message_tx_network: MessageTxNetwork) -> Result<MessageTxAPI, Self::Error> {
         match message_tx_network.message_tx {
             MessageTxAPI::Message(message_tx) => {
-                let mut to_address: fvm_shared::address::Address = message_tx.to.to_owned();
+                let to_address: fvm_shared::address::Address = message_tx.to.to_owned();
 
-                let mut from_address: fvm_shared::address::Address = message_tx.from.to_owned();
+                let from_address: fvm_shared::address::Address = message_tx.from.to_owned();
 
                 let message_with_network = Message {
                     to: to_address,
@@ -247,10 +247,9 @@ impl TryFrom<MessageTxNetwork> for MessageTxAPI {
                 Ok(MessageTxAPI::Message(message_with_network))
             }
             MessageTxAPI::SignedMessage(message_tx) => {
-                let mut to_address: fvm_shared::address::Address = message_tx.message.to.to_owned();
+                let to_address: fvm_shared::address::Address = message_tx.message.to.to_owned();
 
-                let mut from_address: fvm_shared::address::Address =
-                    message_tx.message.from.to_owned();
+                let from_address: fvm_shared::address::Address = message_tx.message.from.to_owned();
 
                 let tmp = message_tx.message.clone();
 

--- a/cli/signer/src/lib.rs
+++ b/cli/signer/src/lib.rs
@@ -239,7 +239,7 @@ pub fn key_recover(private_key: &PrivateKey, testnet: bool) -> Result<ExtendedKe
     Ok(ExtendedKey {
         private_key: PrivateKey(secret_key.serialize()),
         public_key: PublicKey::SECP256K1PublicKey(public_key),
-        address: address,
+        address,
     })
 }
 

--- a/cli/signer/src/lib.rs
+++ b/cli/signer/src/lib.rs
@@ -170,7 +170,7 @@ pub fn key_derive(
 ) -> Result<ExtendedKey, SignerError> {
     let esk = derive_extended_secret_key_from_mnemonic(mnemonic, path, password, language_code)?;
 
-    let mut address = Address::new_secp256k1(esk.public_key().as_ref())?;
+    let address = Address::new_secp256k1(esk.public_key().as_ref())?;
 
     let bip44_path = BIP44Path::from_string(path)?;
 
@@ -198,7 +198,7 @@ pub fn key_derive(
 pub fn key_derive_from_seed(seed: &[u8], path: &str) -> Result<ExtendedKey, SignerError> {
     let esk = derive_extended_secret_key(seed, path)?;
 
-    let mut address = Address::new_secp256k1(esk.public_key().as_ref())?;
+    let address = Address::new_secp256k1(esk.public_key().as_ref())?;
 
     let bip44_path = BIP44Path::from_string(path)?;
 
@@ -256,7 +256,7 @@ pub fn key_recover_bls(
 ) -> Result<ExtendedKey, SignerError> {
     let sk = bls_signatures::PrivateKey::from_bytes(&private_key.0)?;
 
-    let mut address = Address::new_bls(&sk.public_key().as_bytes())?;
+    let address = Address::new_bls(&sk.public_key().as_bytes())?;
 
     let mut network_str = "f".to_owned();
     if testnet {
@@ -408,7 +408,7 @@ fn verify_secp256k1_signature(signature: &Signature, cbor: &Vec<u8>) -> Result<b
     let blob_to_sign = libsecp256k1::Message::parse_slice(&message_digest)?;
 
     let public_key = libsecp256k1::recover(&blob_to_sign, &signature_rs, &recovery_id)?;
-    let mut from = Address::new_secp256k1(public_key.serialize().as_ref())?;
+    let from = Address::new_secp256k1(public_key.serialize().as_ref())?;
 
     let tx_from = match tx {
         MessageTxAPI::Message(tx) => tx.from,
@@ -808,7 +808,7 @@ pub fn verify_voucher_signature(
                 let recovery_id = libsecp256k1::RecoveryId::parse(signature.bytes()[64])?;
                 let message = libsecp256k1::Message::parse(&digest);
                 let public_key = libsecp256k1::recover(&message, &sig, &recovery_id)?;
-                let mut signer = Address::new_secp256k1(public_key.serialize().as_ref())?;
+                let signer = Address::new_secp256k1(public_key.serialize().as_ref())?;
 
                 if signer.to_string() != address.to_string() {
                     Err(SignerError::GenericString(

--- a/cli/signer/src/lib.rs
+++ b/cli/signer/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(test), deny(clippy::expect_used,))]
 use std::convert::TryFrom;
-use std::str::FromStr;
 
 use bip39::{Language, MnemonicType, Seed};
 use bls_signatures::Serialize;
@@ -14,8 +13,8 @@ use zx_bip44::BIP44Path;
 use fil_actor_init::{ExecParams, Method as MethodInit};
 use fil_actor_multisig as multisig;
 use fil_actor_paych as paych;
-use fvm_ipld_encoding::{from_slice, to_vec, Cbor, RawBytes};
-use fvm_shared::address::{set_current_network, Address, Network, Protocol};
+use fvm_ipld_encoding::{from_slice, to_vec, RawBytes};
+use fvm_shared::address::{Address, Network, Protocol};
 
 use bls_signatures::PublicKey as BLSPublicKey;
 use libsecp256k1::PublicKey as SECP256K1PublicKey;


### PR DESCRIPTION
There was a multitude of small warnings showing up when running the cli. As the majority of them were easy fixes, here's a PR to address that.

- Removed unused imports;
- Removed uneeded variable mutability;
- Used shorthand notation for structs.