### PR TITLE
Implement revoke admin cli support

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -21,7 +21,7 @@ use crate::utils::{
     generate_monthly_payout, get_pending_transaction_multisig, get_signing_method_and_address,
     get_unreleased_payout_contracts, grant_admin, inspect_earnings, inspect_multisig, new_payout,
     propose_payout, release_selected_payouts, release_selected_payouts_filecoin_signing,
-    SigningOptions,
+    revoke_admin, SigningOptions,
 };
 
 #[allow(missing_docs)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -353,6 +353,35 @@ impl Cli {
                     .await?;
                 }
             }
+            Commands::RevokeAdmin {
+                address,
+                factory_addr,
+            } => {
+                if self.secret.is_some() {
+                    let client = get_wallet(self.secret.unwrap(), provider).await?;
+                    revoke_admin(
+                        client.clone(),
+                        self.retries,
+                        gas_price,
+                        factory_addr,
+                        address,
+                        &self.rpc_url,
+                    )
+                    .await?;
+                } else {
+                    let client = get_ledger_signing_provider(provider, chain_id.as_u64()).await?;
+                    let client = Arc::new(client);
+                    revoke_admin(
+                        client.clone(),
+                        self.retries,
+                        gas_price,
+                        factory_addr,
+                        address,
+                        &self.rpc_url,
+                    )
+                    .await?;
+                }
+            }
             Commands::InspectEarnings {
                 address,
                 factory_address,
@@ -515,6 +544,17 @@ pub enum Commands {
     #[command(arg_required_else_help = true)]
     GrantAdmin {
         /// Address to grant role to
+        #[arg(short = 'A', long)]
+        address: String,
+        /// PayoutFactory Ethereum address.
+        #[arg(short = 'F', long)]
+        factory_addr: String,
+    },
+    /// Revokes an admin role from a payout factory contract. The issuing address
+    /// has to be an admin on the contract.
+    #[command(arg_required_else_help = true)]
+    RevokeAdmin {
+        /// Address to revoke role from
         #[arg(short = 'A', long)]
         address: String,
         /// PayoutFactory Ethereum address.

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use tabled::{settings::object::Object, Table, Tabled};
 use url::Url;
 
+const EXPLORER_ADDR: &str = "https://explorer.glif.io/tx";
 const ADMIN_ROLE: [u8; 32] = [0; 32];
 
 const LOTUS_RPC_URL: &str = "http://127.0.0.1:1234/rpc/v1";
@@ -1003,7 +1004,13 @@ pub async fn grant_admin<S: ::ethers::providers::Middleware + 'static>(
 
     info!("estimated grant gas cost {:#?}", claim_tx.tx.gas().unwrap());
 
-    send_tx(&claim_tx.tx, client, retries).await?;
+    let receipt_result = send_tx(&claim_tx.tx, client, retries).await?;
+    let transaction_hash = receipt_result.block_hash.unwrap();
+    info!(
+        "admin granted successfully to '{}'. check {}/{}/",
+        address_to_grant, EXPLORER_ADDR, transaction_hash,
+    );
+
     Ok(())
 }
 
@@ -1032,7 +1039,13 @@ pub async fn revoke_admin<S: ::ethers::providers::Middleware + 'static>(
 
     info!("estimated grant gas cost {:#?}", claim_tx.tx.gas().unwrap());
 
-    send_tx(&claim_tx.tx, client, retries).await?;
+    let receipt_result = send_tx(&claim_tx.tx, client, retries).await?;
+    let transaction_hash = receipt_result.block_hash.unwrap();
+    info!(
+        "admin granted successfully to '{}'. check {}/{}/",
+        address_to_revoke, EXPLORER_ADDR, transaction_hash,
+    );
+
     Ok(())
 }
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1005,10 +1005,9 @@ pub async fn grant_admin<S: ::ethers::providers::Middleware + 'static>(
     info!("estimated grant gas cost {:#?}", claim_tx.tx.gas().unwrap());
 
     let receipt_result = send_tx(&claim_tx.tx, client, retries).await?;
-    let transaction_hash = receipt_result.block_hash.unwrap();
     info!(
         "admin granted successfully to '{}'. check {}/{}/",
-        address_to_grant, EXPLORER_ADDR, transaction_hash,
+        address_to_grant, EXPLORER_ADDR, receipt_result.transaction_hash,
     );
 
     Ok(())
@@ -1040,10 +1039,9 @@ pub async fn revoke_admin<S: ::ethers::providers::Middleware + 'static>(
     info!("estimated grant gas cost {:#?}", claim_tx.tx.gas().unwrap());
 
     let receipt_result = send_tx(&claim_tx.tx, client, retries).await?;
-    let transaction_hash = receipt_result.block_hash.unwrap();
     info!(
-        "admin granted successfully to '{}'. check {}/{}/",
-        address_to_revoke, EXPLORER_ADDR, transaction_hash,
+        "admin revoked successfully from '{}'. check {}/{}/",
+        address_to_revoke, EXPLORER_ADDR, receipt_result.transaction_hash,
     );
 
     Ok(())

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -142,6 +142,26 @@ fn cli_4_claim() -> Result<(), Box<dyn std::error::Error>> {
         factory_addr,
         "--addr-to-claim",
         RECIPIENT_ADDRESS,
+    ];
+    args.append(&mut new_payout_args);
+
+    let mut cmd = Command::cargo_bin("saturn-contracts")?;
+    cmd.args(&args);
+    cmd.output().ok();
+    Ok(())
+}
+
+#[test]
+fn cli_5_grant_admin() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = get_const_cli_args();
+
+    let factory_addr = &FACTORY_ADDRESS.lock().unwrap();
+    let mut new_payout_args = vec![
+        "grant-admin",
+        "--factory-addr",
+        factory_addr,
+        "--address",
+        RECIPIENT_ADDRESS,
         "--offset",
         "0",
     ];

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -1,7 +1,6 @@
 use assert_cmd::prelude::*;
 use assert_fs::fixture::FileWriteStr;
 use assert_fs::NamedTempFile;
-use chrono::format;
 use cli::utils::{random_filecoin_address, ATTO_FIL};
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -142,6 +142,8 @@ fn cli_4_claim() -> Result<(), Box<dyn std::error::Error>> {
         factory_addr,
         "--addr-to-claim",
         RECIPIENT_ADDRESS,
+        "--offset",
+        "0",
     ];
     args.append(&mut new_payout_args);
 
@@ -162,8 +164,26 @@ fn cli_5_grant_admin() -> Result<(), Box<dyn std::error::Error>> {
         factory_addr,
         "--address",
         RECIPIENT_ADDRESS,
-        "--offset",
-        "0",
+    ];
+    args.append(&mut new_payout_args);
+
+    let mut cmd = Command::cargo_bin("saturn-contracts")?;
+    cmd.args(&args);
+    cmd.output().ok();
+    Ok(())
+}
+
+#[test]
+fn cli_6_revoke_admin() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = get_const_cli_args();
+
+    let factory_addr = &FACTORY_ADDRESS.lock().unwrap();
+    let mut new_payout_args = vec![
+        "revoke-admin",
+        "--factory-addr",
+        factory_addr,
+        "--address",
+        RECIPIENT_ADDRESS,
     ];
     args.append(&mut new_payout_args);
 


### PR DESCRIPTION
We couldn't really remove admins from the cli, so this should fix that. I wanted to cleanup the code a little bit, but I figured it would be more important to ship this rather than adjust existing functionality for code reuse.

- Added a wrapper to use the contract's `revoke_admin` method;
- Added the clap cli boilerplate to use it.